### PR TITLE
Use the total playcount of the previous episode

### DIFF
--- a/default.py
+++ b/default.py
@@ -59,9 +59,8 @@ class MyPlayer( xbmc.Player ):
                         for episode in jsonobject['result']['episodes']:
                             if(episode['episode'] == (playingEpisode - 1)):
                                 #log("FOUND!")
-                                playcount = episode['playcount']
+                                playcount += episode['playcount']
                                 found = True
-                                break
                         
                         if not found or playcount == 0:
                             #log("Stopping playback!")


### PR DESCRIPTION
If the previous episode is in your library multiple times it needs to be watched only once.

Now if you have these episodes:

Ep 4: unwatched
Ep 4: watched
Ep 5: unwatched

You will get a warning when you try to watch episode 5. This patch removes this warning because it will add the playcount of both Ep 4.
